### PR TITLE
Run file

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+# Make flake happy with black code formatter
+max-line-length = 88
+extend-ignore = E203

--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,6 @@ dmypy.json
 # Audio and text folders
 audio
 transcripts
+
+# Testing outputs
+output

--- a/document_handler/document_to_text.py
+++ b/document_handler/document_to_text.py
@@ -60,16 +60,25 @@ class DocumentReader:
         return "Unknown format. Known formats are .pdf and .pptx"
 
     def save(self, output_path) -> bool:
+        # Clean output_path
+        output_txt = self.to_txt_path(output_path)
+
         try:
-            with open(output_path, "w") as f:
+            with open(output_txt, "w") as f:
                 f.writelines(self.text)
             return True
         except IOError:
             print(
                 "An error occurred while creating or writing to the file: \
-                    {output_path}"
+                    {output_txt}"
             )
             return False
+
+    def to_txt_path(self, path):
+        """Makes a path end with .txt"""
+        output = path.split(".")
+        output[-1] = "txt"
+        return ".".join(output)
 
 
 def main():

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ pdfplumber==0.6.0
 python-pptx==0.6.21
 requests==2.25.1
 tqdm==4.62.0
+Unidecode==1.3.3
 -e .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 beautifulsoup4==4.10.0
 ffmpeg-python==0.2.0
 lxml==4.7.1
+pandas==1.3.1
 pdfplumber==0.6.0
 python-pptx==0.6.21
 requests==2.25.1

--- a/run.py
+++ b/run.py
@@ -316,11 +316,7 @@ def main():
     )
 
     parser.add_argument(
-        "-i",
-        "--input_source_json",
-        required=False,
-        help="Path to the source.json file.",
-        default="test_data.json",
+        "-i", "--input_source_json", required=True, help="Path to the source.json file."
     )
 
     args = parser.parse_args()

--- a/run.py
+++ b/run.py
@@ -12,15 +12,16 @@
 
     Functionality:
     run
-    python run.py -i input.json -o output_folder -ca
+    python run.py -i input.json -o output_folder -wave
 
     this will for each source in input.json
 
     1. Generate the folder structure in the output folder,
         see "generate_folder_structure" for details
     2.
-        a) -ca -> Convert audio to .wav and copy to output folder
+        a) -wave -> Convert audio to .wav and copy to output folder
         b) -gas -> Generate audio symlinks in the audio folder for the source
+        c) -ca -> Copy the audio files to the output folder
     3. Convert text documents to .txt files
         and put them into the text folder for the source
     4. Generate a new mappings.tsv file

--- a/run.py
+++ b/run.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+
+"""
+    This is the main script for handling raw data sources.
+
+    The script assumes that the user has a valid sources.json file which
+    contains necessary information like
+    audio_dir
+    text_dir
+    mappings_dir
+    name
+
+    Functionality:
+    run
+    python main.py -i input.json -o output_folder -ca
+
+    this will for each source in input.json
+
+    1. Generate the folder structure in the output folder,
+        see "generate_folder_structure" for details
+    2.
+        a) -ca -> Convert audio to .wav and copy to output folder
+        b) -gas -> Generate audio symlinks in the audio folder for the source
+    3. Convert text documents to .txt files
+        and put them into the text folder for the source
+    4. Generate a new mappings.tsv file
+
+
+"""
+
+___author___ = "Staffan Hedström"
+___license___ = "Apache 2.0"
+___copyright___ = "2022 Staffan Hedström Reykjavík University"
+
+from source_handler.handler import Source, SourceHandler
+from document_handler.document_to_text import DocumentReader
+from utilities.utilities import copy_and_convert_to_wav
+import os
+import logging
+import argparse
+import pandas as pd
+from pathlib import Path
+
+
+def generate_folder_structure(source_names: list, destination) -> None:
+    """
+    Generates the desired folder structure in the destination folder
+    Creates all folders to the destination path as necessary
+
+    Folder structure
+    destination_folder/
+        |___source_1_name/
+            |____audio/
+            |____text/
+        |___source_2_name/
+            |___audio/
+            |___text/
+        ...
+    """
+    for name in source_names:
+        path = os.path.join(destination, name)
+        audio_path = os.path.join(path, "audio")
+        text_path = os.path.join(path, "text")
+
+        try:
+            os.makedirs(audio_path)
+            os.makedirs(text_path)
+        except FileExistsError:
+            logging.warning(f"Folder {audio_path} or {text_path} already exists")
+
+
+def generate_txt_files(sources: list, destination) -> None:
+    """
+    Converts all text files to txt files and places them in the
+    destination / source_name / text folder.
+    """
+    reader = DocumentReader()
+
+    for source in sources:
+        if isinstance(source, Source):
+            if not os.path.exists(source.text_dir):
+                logging.error(
+                    f"Audio path for {source.name_ascii} \
+                        cannot be found: '{source.text_dir}' \
+                        skipping..."
+                )
+                continue
+            text_dest_folder = os.path.join(destination, source.name_ascii, "text")
+            for root, dirs, files in os.walk(source.text_dir):
+                for file in files:
+                    reader.read(os.path.join(root, file))
+                    reader.save(os.path.join(text_dest_folder, file))
+
+
+def generate_audio(sources: list, destination, copy=False) -> None:
+    """
+    Generates audio symlinks into the destination path for each source.
+
+    Uses the source audio dir to find the original audio files, and for each
+    creates a symlink in the destination / source_name / audio folder.
+
+    This relies on that the folder structure has already been created.
+    """
+    for source in sources:
+        if isinstance(source, Source):
+            if not os.path.exists(source.audio_path):
+                logging.error(
+                    f"Audio path for {source.name_ascii} \
+                        cannot be found: '{source.audio_path}'"
+                )
+            audio_folder = os.path.join(destination, source.name_ascii, "audio")
+            for root, dirs, files in os.walk(source.audio_path):
+                logging.info(f"Found {len(files)} audio files for {source.name_ascii}")
+                for file in files:
+                    try:
+                        if copy:
+                            copy_and_convert_to_wav(
+                                os.path.join(root, file),
+                                os.path.join(audio_folder, file),
+                            )
+                        else:  # else create symlinks to save space
+                            if ".wav" not in file:
+                                logging.warn(
+                                    "The audio is not in .wav format. \
+                                    Continue with care or run with -ca command."
+                                )
+                            os.symlink(
+                                os.path.join(root, file),
+                                os.path.join(audio_folder, file),
+                            )
+
+                    except FileExistsError:
+                        logging.warn(
+                            f"File: '{os.path.join(audio_folder, file)}' already exits"
+                        )
+
+
+def __format_audio_mapping(path: str) -> str:
+    return str(Path("audio") / Path(path).name)
+
+
+def __format_text_mapping(path: str) -> str:
+    return str(Path("text") / f"{Path(path).stem}.txt")
+
+
+def map_and_standardize_filenames(sources: list, destination) -> None:
+    for source in sources:
+        if isinstance(source, Source):
+            if not os.path.exists(source.mapping_file):
+                logging.error(
+                    f"Cannot find the mapping file: {source.mapping_file} for {source}"
+                )
+                continue
+        mapping = pd.read_csv(source.mapping_file, sep="\t")
+
+        mapping.audio = mapping.audio.apply(__format_audio_mapping)
+        mapping.text = mapping.text.apply(__format_text_mapping)
+
+        mapping = standardize_files(mapping, destination, source.name_ascii)
+
+        # Check if file exists?
+        mapping.to_csv(Path(destination, source.name_ascii, "mapping.tsv"), sep="\t")
+
+
+def standardize_files(
+    mapping_dataframe: pd.DataFrame, destination, source_name
+) -> pd.DataFrame:
+    """
+    Standardizes the files in the destination folder according to
+    source_name_000XX.txt
+    source_name_000XX.wav
+
+    Uses the data in the mapping_dataframe to rename the files sp
+    that the audio file and matching text file have matching names.
+    """
+    audio_new_files = []
+    text_new_files = []
+
+    audio_folder = Path(destination, source_name, "audio")
+    text_folder = Path(destination, source_name, "text")
+
+    for row in mapping_dataframe.iterrows():
+        file_number = row[0] + 1
+        audio = f"{Path(row[1].audio).stem}.wav"
+        text = f"{Path(row[1].text).stem}.txt"
+        audio_new_name = f"{source_name}_{str(file_number).zfill(6)}.wav"
+        text_new_name = f"{source_name}_{str(file_number).zfill(6)}.txt"
+
+        os.rename(Path(audio_folder, audio), Path(audio_folder, audio_new_name))
+        os.rename(Path(text_folder, text), Path(text_folder, text_new_name))
+
+        audio_new_files.append(audio_new_name)
+        text_new_files.append(text_new_name)
+
+    mapping_dataframe.audio = audio_new_files
+    mapping_dataframe.text = text_new_files
+
+    return mapping_dataframe
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Formats and converts the data into a ready for alignment state"
+    )
+
+    parser.add_argument(
+        "-skip_fs",
+        "--skip_folder_structure",
+        required=False,
+        help="Use this flag to skip the generation of the folder structure.",
+        action="store_true",
+    )
+
+    parser.add_argument(
+        "-gas",
+        "--generate_audio_symlinks",
+        required=False,
+        help="Use this flag to generate audio symlinks. Only use this if you know the \
+            audio has the correct format already.",
+        action="store_false",
+    )
+
+    parser.add_argument(
+        "-sd",
+        "--skip_convert_documents",
+        required=False,
+        help="Use this flag to skip the convertion of documents (pdf, pptx...) to .txt",
+        action="store_true",
+    )
+
+    parser.add_argument(
+        "-sm",
+        "--skip_mapping",
+        required=False,
+        help="Use this flag to skip the generation of a mapping file.",
+        action="store_true",
+    )
+
+    parser.add_argument(
+        "-ca",
+        "--copy_audio",
+        required=False,
+        help="Use this flag to convert the audio to .wav and copy it to the output folder. \
+            Will take precedence over generate audio symlinks.",
+        action="store_true",
+    )
+
+    parser.add_argument(
+        "-output",
+        "--output_folder",
+        required=False,
+        help="Set the path to the output folder. default=output",
+        default="output",
+    )
+
+    parser.add_argument(
+        "-i",
+        "--input_source_json",
+        required=False,
+        help="Path to the source.json file.",
+        default="test_data.json",
+    )
+
+    args = parser.parse_args()
+
+    # Source handler
+    source_file = args.input_source_json
+    source_handler = SourceHandler(source_file)
+
+    # Output folder
+    output = args.output_folder
+    sources = source_handler.get_sources()
+    sources_names = source_handler.get_source_names_ascii()
+
+    if not args.skip_folder_structure:
+        generate_folder_structure(sources_names, output)
+
+    if args.copy_audio:
+        generate_audio(sources, output, copy=True)
+
+    elif args.generate_audio_symlinks:
+        generate_audio(sources, output)
+
+    if not args.skip_convert_documents:
+        generate_txt_files(sources, output)
+
+    # Mapping has to be done before
+    # This should only generate a new mapping file with new file names and file
+    # extensions
+    if not args.skip_mapping:
+        map_and_standardize_filenames(sources, output)
+
+
+if __name__ == "__main__":
+    main()

--- a/source_handler/handler.py
+++ b/source_handler/handler.py
@@ -92,9 +92,9 @@ class SourceHandler:
         if not source.name:
             logging.warning("Source is missing name. Skipping")
             return False
-        if not source.url:
+        if not source.rss_feed_url:
             logging.warning(
-                f"Source: '{source.name}' is missing url. \
+                f"Source: '{source.name}' is missing a rss feed url. \
                 This is ok as long as you are not downloading the sources."
             )
         if not source.audio_path:

--- a/source_handler/handler.py
+++ b/source_handler/handler.py
@@ -92,16 +92,28 @@ class SourceHandler:
         if not source.name:
             logging.warning("Source is missing name. Skipping")
             return False
-        if not source.url: 
-            logging.warning(f"Source: '{source.name}' is missing url. This is ok as long as you are not downloading the sources.")
-        if not source.audio_path: 
-            logging.warning(f"Source: '{source.name}' is missing audio dir path. Skipping this source...")
+        if not source.url:
+            logging.warning(
+                f"Source: '{source.name}' is missing url. \
+                This is ok as long as you are not downloading the sources."
+            )
+        if not source.audio_path:
+            logging.warning(
+                f"Source: '{source.name}' is missing audio dir path. \
+                    Skipping this source..."
+            )
             return False
         if not source.text_dir:
-            logging.warning(f"Source: '{source.name}' is missing text dir path. Skipping this source...")
+            logging.warning(
+                f"Source: '{source.name}' is missing text dir path. \
+                     Skipping this source..."
+            )
             return False
         if not source.mapping_file:
-            logging.warning(f"Source '{source.name}' is missing a mapping file. Skipping this source...")
+            logging.warning(
+                f"Source '{source.name}' is missing a mapping file. \
+                    Skipping this source..."
+            )
             return False
 
         return True
@@ -116,12 +128,12 @@ class SourceHandler:
             mapping_file = source[Headers.MAPPING_FILE]
 
             source_to_add = Source(
-                    name=name,
-                    text_dir=text_dir,
-                    audio_dir=audio_dir,
-                    rss_feed_url=url,
-                    mapping_file=mapping_file,
-                )
+                name=name,
+                text_dir=text_dir,
+                audio_dir=audio_dir,
+                rss_feed_url=url,
+                mapping_file=mapping_file,
+            )
 
             # Validate each source before adding
             if self.valid_source(source_to_add):

--- a/source_handler/handler.py
+++ b/source_handler/handler.py
@@ -20,6 +20,7 @@ ___copyright___ = "2022 Staffan Hedström Reykjavík University"
 
 import json
 from utilities.utilities import standardize_string
+import logging
 
 
 class Headers(object):
@@ -87,6 +88,24 @@ class SourceHandler:
 
         return feeds
 
+    def valid_source(self, source: Source) -> bool:
+        if not source.name:
+            logging.warning("Source is missing name. Skipping")
+            return False
+        if not source.url: 
+            logging.warning(f"Source: '{source.name}' is missing url. This is ok as long as you are not downloading the sources.")
+        if not source.audio_path: 
+            logging.warning(f"Source: '{source.name}' is missing audio dir path. Skipping this source...")
+            return False
+        if not source.text_dir:
+            logging.warning(f"Source: '{source.name}' is missing text dir path. Skipping this source...")
+            return False
+        if not source.mapping_file:
+            logging.warning(f"Source '{source.name}' is missing a mapping file. Skipping this source...")
+            return False
+
+        return True
+
     def get_sources(self) -> list:
         s = []
         for source in self.sources:
@@ -95,15 +114,18 @@ class SourceHandler:
             text_dir = source[Headers.TEXT_DIR]
             audio_dir = source[Headers.AUDIO_DIR]
             mapping_file = source[Headers.MAPPING_FILE]
-            s.append(
-                Source(
+
+            source_to_add = Source(
                     name=name,
                     text_dir=text_dir,
                     audio_dir=audio_dir,
                     rss_feed_url=url,
                     mapping_file=mapping_file,
                 )
-            )
+
+            # Validate each source before adding
+            if self.valid_source(source_to_add):
+                s.append(source_to_add)
 
         return s
 

--- a/source_handler/handler.py
+++ b/source_handler/handler.py
@@ -19,6 +19,7 @@ ___license___ = "Apache 2.0"
 ___copyright___ = "2022 Staffan Hedström Reykjavík University"
 
 import json
+from utilities.utilities import standardize_string
 
 
 class Headers(object):
@@ -26,6 +27,21 @@ class Headers(object):
     LAST_UPDATED = "last_updated"
     NAME = "name"
     RSS_URL = "rss_feed"
+    TEXT_DIR = "text_dir"
+    AUDIO_DIR = "audio_dir"
+    MAPPING_FILE = "mapping_file"
+
+
+class Source:
+    def __init__(
+        self, name, text_dir=None, audio_dir=None, rss_feed_url=None, mapping_file=None
+    ) -> None:
+        self.name = name
+        self.name_ascii = standardize_string(name)
+        self.text_dir = text_dir
+        self.audio_path = audio_dir
+        self.rss_feed_url = rss_feed_url
+        self.mapping_file = mapping_file
 
 
 class SourceHandler:
@@ -42,6 +58,14 @@ class SourceHandler:
 
         for source in self.sources:
             names.append(source[Headers.NAME])
+
+        return names
+
+    def get_source_names_ascii(self):
+        names = []
+
+        for source in self.sources:
+            names.append(standardize_string(source[Headers.NAME]))
 
         return names
 
@@ -62,6 +86,26 @@ class SourceHandler:
             feeds[name] = url
 
         return feeds
+
+    def get_sources(self) -> list:
+        s = []
+        for source in self.sources:
+            name = source[Headers.NAME]
+            url = source[Headers.RSS_URL]
+            text_dir = source[Headers.TEXT_DIR]
+            audio_dir = source[Headers.AUDIO_DIR]
+            mapping_file = source[Headers.MAPPING_FILE]
+            s.append(
+                Source(
+                    name=name,
+                    text_dir=text_dir,
+                    audio_dir=audio_dir,
+                    rss_feed_url=url,
+                    mapping_file=mapping_file,
+                )
+            )
+
+        return s
 
 
 def main():

--- a/utilities/utilities.py
+++ b/utilities/utilities.py
@@ -14,8 +14,38 @@ ___author___ = "Staffan Hedström"
 ___license___ = "Apache 2.0"
 ___copyright___ = "2022 Staffan Hedström Reykjavík University"
 
+import unidecode
+import ffmpeg
+
 
 def seconds_to_hours_mins(seconds):
     mins = int((seconds / 60) % 60)
     hours = int(seconds / 60 / 60)
     return hours, mins
+
+
+def standardize_string(string):
+    return unidecode.unidecode(string.lower().replace(" ", "_"))
+
+
+def copy_and_convert_to_wav(input, output):
+    """
+    Uses ffmpeg to convert the intput file to a .wav
+    and places a copy of it at output
+    """
+    file_format = output.split(".")[-1]
+    if file_format != "wav":
+        output = output.split(".")
+        output[-1] = "wav"
+        output = ".".join(output)
+    stream = ffmpeg.input(input)
+    stream = ffmpeg.output(
+        stream,
+        filename=output,
+        f="wav",
+        acodec="pcm_s16le",
+        ac=1,
+        ar="16k",
+        loglevel="error",
+    )
+    ffmpeg.run(stream)


### PR DESCRIPTION
This creates the run file.

Standard usage would be
python run.py -i sources.json -o path/to/output/folder -ca

Where -ca stands for copy and convert audio (maybe it should be called caca?)
Another option is -gas -> generate audio symlinks, which can be used when the source audio is available and already .wav

This will
1. Generate the folder structure
2. Convert all .pdf and .pptx to txt and place at the correct place
3. Convert all audio to .wav and palce at the correct place
4. Standardize the audio and text names with the help of a mappings file.

The output from a test source has been reviewed and gotten thumbs up from asr-person.