### PR TITLE
Trim

### DIFF
--- a/document_handler/document_to_text.py
+++ b/document_handler/document_to_text.py
@@ -125,7 +125,7 @@ class DocumentReader:
         Checks if a trim item is a command.
         Returns the command if it is or empty string if not.
         """
-        command = re.search("\+{3}(.*)\+{3}", trim)
+        command = re.search(r"\+{3}(.*)\+{3}", trim)
         if command is None:
             return ""
         return command.group(1)
@@ -176,7 +176,7 @@ class DocumentReader:
         # Make it all into one string
         output = " ".join(text)
         # Split on "." to find sentences
-        output = re.split("\. ", output)
+        output = re.split(r"\. ", output)
         output = [x + "." for x in output]
         # If last line has a dot, an additional one will be added
         output[-1] = output[-1].replace("..", ".")

--- a/document_handler/document_to_text.py
+++ b/document_handler/document_to_text.py
@@ -25,15 +25,30 @@ from pptx import Presentation
 import pdfplumber
 from docx import Document
 import re
+from pathlib import Path
 
-# Trim commands
+# Trim commands, using input1___input2+++command+++
 REMOVE_TABBED = "tabs"
 REMOVE_WORD = "word"
+REMOVE_FROM_TO = "remove_from_to"
+CONTAINS_MULTIPLE = (
+    "contains_multiple"  # " / ___3" => removes lines containing 3x " / "
+)
+REMOVE_NUMBER = "remove_number"  # "part ___3" -> removes line where "part " is followed by 3 or more numbers
+TIME_TO_TIME = "time_to_time"  # removes 0.00 – 1.34 and similar
+EXACT = "exact"
+SONGS = "songs"
+TO_GUEST = "to_guest"
+ALL_UPPERCASE = "all_uppercase"
+REMOVE_START_TIME = "start_time"
+REMOVE_SPEAKER_IDENTIFIER = "remove_speaker"
+ONLY_NUMBERS = "only_numbers"
 
 
 class DocumentReader:
     def __init__(self) -> None:
         self.text = []
+        self.guest = []
 
     def text_from_presentation(self, filepath) -> list:
         prs = Presentation(filepath)
@@ -68,7 +83,7 @@ class DocumentReader:
         docx = Document(filepath)
         for p in docx.paragraphs:
             line = p.text
-            if line == "":  # Skip empty lines
+            if line == "" and len(text) >= 1 and text[-1] == "":  # Skip empty lines
                 continue
             # Perserve tabs
             try:
@@ -94,11 +109,24 @@ class DocumentReader:
         trimmed_text = []
 
         for line in self.text:
+            if line == "" and len(trimmed_text) >= 1 and trimmed_text[-1] != "":
+                trimmed_text.append(line)
+                continue
             trimmed = self.trim_line(line, trim_list)
             # Skip empty lines
             if trimmed == "":
                 continue
             trimmed_text.append(trimmed)
+
+        for trim_item in trim_list:
+            command = self.is_trim_command(trim_item)
+            if not command == REMOVE_FROM_TO:
+                continue
+            start, end = trim_item.replace(f"+++{command}+++", "").split("___")
+
+        # Lastly remove empty lines
+        trimmed_text = [line for line in trimmed_text if line.strip() != ""]
+        self.guest = [line for line in self.guest if line.strip() != ""]
         self.text = trimmed_text
         return trimmed_text
 
@@ -108,14 +136,79 @@ class DocumentReader:
         """
         for trim_item in trim_list:
             command = self.is_trim_command(trim_item)
+            second_command = None
+            if len(command.split(",")) == 2:
+                command, second_command = command.split(",")
             if command == REMOVE_TABBED:
                 if "\t" in line:
+                    if second_command == TO_GUEST:
+                        self.guest.append(line.strip())
                     return ""
             if command == REMOVE_WORD:
                 word = trim_item.replace(f"+++{command}+++", "")
                 if word in line:
                     trimmed = line.replace(word, "")
                     return " ".join(trimmed.split())
+            if command == REMOVE_NUMBER:
+                word, num_digits = trim_item.replace(f"+++{command}+++", "").split(
+                    "___"
+                )
+                found = re.match("%s\d{%s,}" % (word, num_digits), line.strip())
+                if found:
+                    return ""
+            if command == CONTAINS_MULTIPLE:
+                char, amount = trim_item.replace(f"+++{command}+++", "").split("___")
+                count = line.count(char)
+                if count >= int(amount):
+                    return ""
+            if command == TIME_TO_TIME:
+                found = (
+                    re.search(r"\d+(\:|\.)\d+\s?(–|-)\s?\d+(\:|\.)\d+", line) != None
+                )
+
+                if found:
+                    return ""
+            if command == EXACT:
+                word = trim_item.replace(f"+++{command}+++", "")
+                if line == word:
+                    return ""
+            if command == SONGS:
+                # Numbered songs
+                found = (
+                    re.match(
+                        r"\d{2}\.\s?([A-Za-z\.\&\']+\s)+\s?(-|-)\s?([A-Za-z\.\&\']+\s)+",
+                        line.strip(),
+                    )
+                    != None
+                )
+                if found:
+                    return ""
+            if command == ALL_UPPERCASE:
+                found = re.search(r"^\t?[A-ZÁÐÉÍÓÚÝÞÆÖ \.\:\-\+\,]+$", line)
+                if found:
+                    return ""
+            if command == REMOVE_START_TIME:
+                found = re.match(r"\t?\d+(\.|\:)\d+(\s|$)", line)
+                if found:
+                    res = line.replace(found.group(0), "").strip()
+                    if second_command == TO_GUEST:
+                        self.guest.append(res)
+                        return ""
+                    return res
+            if command == REMOVE_SPEAKER_IDENTIFIER:
+                found = re.match(r"\t*[A-ZÁÐÉÍÓÚÝÞÆÖ]+ ?[A-ZÁÐÉÍÓÚÝÞÆÖ]*\:", line)
+                if found:
+                    res = line.replace(found.group(0), "").strip()
+                    if second_command == TO_GUEST:
+                        self.guest.append(res)
+                        return ""
+                    return res
+
+            if command == ONLY_NUMBERS:
+                found = re.match(r"^[\d\:\,\.\/\\]+$", line.strip())
+                if found:
+                    return ""
+
             if trim_item in line:
                 return ""
         return " ".join(line.split())
@@ -131,11 +224,12 @@ class DocumentReader:
         return command.group(1)
 
     def read(self, filepath: str) -> list:
-        if ".pptx" in filepath:
+        suffix = Path(filepath).suffix
+        if ".pptx" in suffix:
             return self.text_from_presentation(filepath)
-        if ".pdf" in filepath:
+        if ".pdf" in suffix:
             return self.text_from_pdf(filepath)
-        if ".docx" in filepath or ".doc" in filepath:
+        if suffix in [".docx", ".doc", "odt"]:
             return self.text_from_docx(filepath)
         return "Unknown format. Known formats are ['.pdf','.pptx', '.docx', '.doc']"
 
@@ -148,7 +242,16 @@ class DocumentReader:
                 for line in self.text:
                     f.write(line)
                     f.write("\n")
+
+                    # Save guest text if available
+            if len(self.guest) > 0:
+                output_guest = output_txt.replace(".txt", ".guest")
+                with open(output_guest, "w") as f:
+                    for line in self.guest:
+                        f.write(line)
+                        f.write("\n")
             return True
+
         except IOError:
             print(
                 "An error occurred while creating or writing to the file: \
@@ -163,6 +266,7 @@ class DocumentReader:
         return ".".join(output)
 
     def read_and_trim(self, path: str, trim_list: list) -> list:
+        self.guest = []
         text = self.read(path)
         text = self.trim(trim_list)
         # PDFs has odd newline characters, after trimming

--- a/run.py
+++ b/run.py
@@ -229,6 +229,7 @@ def standardize_files(
     """
     audio_new_files = []
     text_new_files = []
+    text_guest_files = []
 
     audio_folder = Path(destination, source_name, "audio")
     text_folder = Path(destination, source_name, "text")
@@ -242,17 +243,27 @@ def standardize_files(
             audio = audio.replace(audio_format, ".wav")
             audio_format = ".wav"
         text = f"{Path(row[1].text).stem}.txt"
-        audio_new_name = f"{source_name}_{str(file_number).zfill(6)}{audio_format}"
-        text_new_name = f"{source_name}_{str(file_number).zfill(6)}.txt"
+        audio_new_name = f"{source_name}_{str(file_number).zfill(3)}{audio_format}"
+        text_new_name = f"{source_name}_{str(file_number).zfill(3)}.txt"
 
         os.rename(Path(audio_folder, audio), Path(audio_folder, audio_new_name))
         os.rename(Path(text_folder, text), Path(text_folder, text_new_name))
+
+        # ALso rename potential guest file
+        guest_file = Path(str(Path(text_folder, text)).replace(".txt", ".guest"))
+        if guest_file.exists():
+            new_guest_file_name = text_new_name.replace(".txt", ".guest")
+            os.rename(guest_file, Path(text_folder, new_guest_file_name))
+            text_guest_files.append(new_guest_file_name)
+        else:
+            text_guest_files.append("")
 
         audio_new_files.append(audio_new_name)
         text_new_files.append(text_new_name)
 
     mapping_dataframe.text = text_new_files
     mapping_dataframe.audio = audio_new_files
+    mapping_dataframe["guest"] = text_guest_files
 
     return mapping_dataframe
 
@@ -276,7 +287,7 @@ def main():
         required=False,
         help="Use this flag to generate audio symlinks. Only use this if you know the \
             audio has the correct format already.",
-        action="store_false",
+        action="store_true",
     )
 
     parser.add_argument(

--- a/run.py
+++ b/run.py
@@ -101,7 +101,7 @@ def generate_txt_files(sources: list, destination) -> None:
         for root, dirs, files in os.walk(source.text_dir):
             for file in tqdm(files, f"Converting documents for {source.name_ascii}"):
                 if file in mapping.text.values:
-                    reader.read(os.path.join(root, file))
+                    reader.read_and_trim(os.path.join(root, file), source.trim_list)
                     reader.save(os.path.join(text_dest_folder, file))
 
 
@@ -190,7 +190,7 @@ def __format_text_mapping(path: str) -> str:
     return str(Path("text") / f"{Path(path).stem}.txt")
 
 
-def map_and_standardize_filenames(sources: list, destination) -> None:
+def map_and_standardize_filenames(sources: list, destination, wave) -> None:
     for source in tqdm(sources, "Standardizing filenames."):
         if not isinstance(source, Source):
             logging.error(f"Cannot read source: {source}")
@@ -208,7 +208,7 @@ def map_and_standardize_filenames(sources: list, destination) -> None:
         mapping.audio = mapping.audio.apply(__format_audio_mapping)
         mapping.text = mapping.text.apply(__format_text_mapping)
 
-        mapping = standardize_files(mapping, destination, source.name_ascii)
+        mapping = standardize_files(mapping, destination, source.name_ascii, wave)
 
         # Check if file exists?
         mapping.to_csv(
@@ -217,7 +217,7 @@ def map_and_standardize_filenames(sources: list, destination) -> None:
 
 
 def standardize_files(
-    mapping_dataframe: pd.DataFrame, destination, source_name
+    mapping_dataframe: pd.DataFrame, destination, source_name, wave
 ) -> pd.DataFrame:
     """
     Standardizes the files in the destination folder according to
@@ -237,6 +237,10 @@ def standardize_files(
         file_number = row[0] + 1
         audio = f"{Path(row[1].audio).name}"
         audio_format = Path(row[1].audio).suffix
+
+        if wave:
+            audio = audio.replace(audio_format, ".wav")
+            audio_format = ".wav"
         text = f"{Path(row[1].text).stem}.txt"
         audio_new_name = f"{source_name}_{str(file_number).zfill(6)}{audio_format}"
         text_new_name = f"{source_name}_{str(file_number).zfill(6)}.txt"
@@ -354,7 +358,7 @@ def main():
 
     # Step 5 Standardize file names in and outside of mappings file
     if not args.skip_mapping:
-        map_and_standardize_filenames(sources, output)
+        map_and_standardize_filenames(sources, output, wave=args.convert_to_wave)
 
 
 if __name__ == "__main__":

--- a/source_handler/handler.py
+++ b/source_handler/handler.py
@@ -31,11 +31,18 @@ class Headers(object):
     TEXT_DIR = "text_dir"
     AUDIO_DIR = "audio_dir"
     MAPPING_FILE = "mapping_file"
+    TRIM_LIST = "trim_list"
 
 
 class Source:
     def __init__(
-        self, name, text_dir=None, audio_dir=None, rss_feed_url=None, mapping_file=None
+        self,
+        name,
+        text_dir=None,
+        audio_dir=None,
+        rss_feed_url=None,
+        mapping_file=None,
+        trim_list=None,
     ) -> None:
         self.name = name
         self.name_ascii = standardize_string(name)
@@ -43,6 +50,7 @@ class Source:
         self.audio_path = audio_dir
         self.rss_feed_url = rss_feed_url
         self.mapping_file = mapping_file
+        self.trim_list = trim_list
 
 
 class SourceHandler:
@@ -126,6 +134,7 @@ class SourceHandler:
             text_dir = source[Headers.TEXT_DIR]
             audio_dir = source[Headers.AUDIO_DIR]
             mapping_file = source[Headers.MAPPING_FILE]
+            trim_list = source[Headers.TRIM_LIST]
 
             source_to_add = Source(
                 name=name,
@@ -133,6 +142,7 @@ class SourceHandler:
                 audio_dir=audio_dir,
                 rss_feed_url=url,
                 mapping_file=mapping_file,
+                trim_list=trim_list,
             )
 
             # Validate each source before adding


### PR DESCRIPTION
Add trimming functionality.

This adds trimming functions to the read and convert document functions.

To use this, in the input sources json, add a trimming list like so
`      "trim_list": [
        "+++tabs+++",
        "STEF",
        "EFFEKT:",
        "LESARI",
        "hljóð:",
        "HLJÓÐ",
        "effekt:",
        "https://youtu",
        "LAG ",
        "ÞÁTTARSTEF",
        "KLIPP",
        "https://www.",
        "KÚNSTPÁSA",
        "sándeffekt - sjá komment"
      ]`

The trimming works like this. All the text will be split into sentences.
Each sentence that contains a string in the trim list will be deleted.

Ex: The text you want to trim has a lot of youtube links to songs used. Like this:
_In this podcast we talk a lot about Elvis,
play in background: https://www.youtube.com/watch?v=vGJTaP6anOU&ab_channel=ElvisPresleyVEVO
we can't help loving Elvis!_


 Remove these by adding the trim tag
"https://youtube"
or
"play in background:"

+++{command}+++ identifies a command. Current supported commands are
tabs
word

tabs: will remove all sentences that includes a tab
word: will only remove the word, not the entire sentence
